### PR TITLE
Polaris: file not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ For used-frameworks "npm", it runs `npm audit`.
 
 Prints out a Markdown table with all environment variables declared in kubedev.json and their documentation.
 
+## kubedev audit
+
+Audits the k8s specification using polaris. If the custom configuration file 
+could not be found or was not specified, polaris falls back on using the 
+default configuration.
+
 ## kubedev up [--clean]
 
 ❌ _NOT IMPLEMENTED, YET_

--- a/kubedev/kubedev.py
+++ b/kubedev/kubedev.py
@@ -414,6 +414,17 @@ class Kubedev:
                         env_accessor=RealEnvAccessor()):
     try:
       polaris_config_exists = False if not kubedev["polaris-config"] else True
+      if path.isfile(kubedev["polaris-config"]):
+        polaris_config_exists = True
+        print(
+          "Using custom polaris configuration file to audit the k8s spec."
+        )
+      else:
+        polaris_config_exists = False
+        print(
+          "❌  Custom polaris configuration file not found!\n"
+          "➡️   Using default configuration to audit the k8s spec."
+        )
     except KeyError:
       polaris_config_exists = False
     k8s_spec        = self.template_from_config(


### PR DESCRIPTION
- fall back on using the default Polaris configuration if the specified config could not be found on the filesystem
- added kubedev audit to README